### PR TITLE
Allow artifact overwrites and include hash file

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -36,6 +36,7 @@ jobs:
                   name: identity_api_build
                   path: ./target/release/identity-api
                   retention-days: 1
+                  overwrite: true
 
     build_app:
         runs-on: ubuntu-24.04
@@ -60,7 +61,9 @@ jobs:
                   path: |
                       ./target/app
                       ./target/release/identity-app
+                      ./target/release/hash-app.txt
                   retention-days: 1
+                  overwrite: true
 
     build_cli:
         runs-on: ubuntu-24.04
@@ -83,6 +86,7 @@ jobs:
                   name: identity_cli_build
                   path: ./target/release/identity-cli
                   retention-days: 1
+                  overwrite: true
 
     build_monitor:
         runs-on: ubuntu-24.04
@@ -105,6 +109,7 @@ jobs:
                   name: identity_monitor_build
                   path: ./target/release/identity-monitor
                   retention-days: 1
+                  overwrite: true
 
     release:
         runs-on: ubuntu-24.04


### PR DESCRIPTION
Add overwrite: true to upload-artifact steps for identity_api, identity_app, identity_cli, and identity_monitor. Also add ./target/release/hash-app.txt to the build_app artifact paths.