### PR TITLE
Add trusted application support

### DIFF
--- a/app/src/pages/authorize_page.rs
+++ b/app/src/pages/authorize_page.rs
@@ -6,6 +6,7 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::pages::AuthenticatedPage;
+use crate::presenters::ApplicationPresenter;
 use crate::server_fns;
 
 #[derive(Clone, Default, Params, PartialEq)]
@@ -49,12 +50,28 @@ pub fn AuthorizePage() -> impl IntoView {
     });
     let action_value = action.value();
 
+    Effect::watch(
+        move || application_resource.get(),
+        move |application, _, _| {
+            if let Some(Ok(ApplicationPresenter {
+                id: _,
+                name: _,
+                is_trusted: true,
+            })) = application
+            {
+                action.dispatch(query.get_untracked().unwrap_or_default());
+            }
+        },
+        false,
+    );
+
     view! {
         <AuthenticatedPage title="Authorize Application">
             <Suspense>
                 {move || Suspend::new(async move {
                     match (application_resource.get(), action_value.get()) {
-                        (Some(Ok(_)), Some(Ok(_))) => {
+                        (Some(Ok(ApplicationPresenter { id: _, name: _, is_trusted: true })), None)
+                        | (Some(Ok(_)), Some(Ok(_))) => {
                             EitherOf5::A(view! { <div class="text-center">"Redirecting..."</div> })
                         }
                         (Some(Ok(_)), Some(Err(_))) => {
@@ -73,7 +90,7 @@ pub fn AuthorizePage() -> impl IntoView {
                                             <div class="card-actions">
                                                 <button
                                                     on:click=move |_| {
-                                                        action.dispatch(query.get().unwrap_or_default());
+                                                        action.dispatch(query.get_untracked().unwrap_or_default());
                                                     }
                                                     class="btn-submit"
                                                     disabled=move || action.pending().get()

--- a/app/src/presenters.rs
+++ b/app/src/presenters.rs
@@ -10,6 +10,7 @@ use identity_core::models::{Application, User};
 pub struct ApplicationPresenter {
     pub id: Uuid,
     pub name: String,
+    pub is_trusted: bool,
 }
 
 #[cfg(feature = "ssr")]
@@ -18,6 +19,7 @@ impl From<Application<'_>> for ApplicationPresenter {
         ApplicationPresenter {
             id: application.id,
             name: application.name.to_string(),
+            is_trusted: application.is_trusted(),
         }
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -26,6 +26,8 @@ enum CliCommand {
         name: String,
         #[arg(short, long)]
         redirect_url: String,
+        #[arg(short, long)]
+        trusted: Option<bool>,
     },
     CreateApplicationToken {
         #[arg(short, long)]
@@ -64,6 +66,8 @@ enum CliCommand {
         name: Option<String>,
         #[arg(short, long)]
         redirect_url: Option<String>,
+        #[arg(short, long)]
+        trusted: Option<bool>,
     },
 }
 
@@ -146,10 +150,15 @@ async fn main() {
                 Err(err) => println!("Failed to get application_tokens.\n\n{err}"),
             }
         }
-        CliCommand::CreateApplication { name, redirect_url } => {
+        CliCommand::CreateApplication {
+            name,
+            redirect_url,
+            trusted,
+        } => {
             let result = commands::insert_application(ApplicationParams {
                 name: name.clone(),
                 redirect_url: redirect_url.clone(),
+                trusted: trusted.unwrap_or(false),
             })
             .await;
 
@@ -232,7 +241,12 @@ async fn main() {
                 Err(err) => println!("Failed to revoke application token.\n\n{err}"),
             }
         }
-        CliCommand::UpdateApplication { id, name, redirect_url } => {
+        CliCommand::UpdateApplication {
+            id,
+            name,
+            redirect_url,
+            trusted,
+        } => {
             if name.is_none() && redirect_url.is_none() {
                 println!("No changes to update.");
                 return;
@@ -246,6 +260,7 @@ async fn main() {
                 ApplicationParams {
                     name: name.clone().unwrap_or(application.name.to_string()),
                     redirect_url: redirect_url.clone().unwrap_or(application.redirect_url.to_string()),
+                    trusted: trusted.unwrap_or(application.is_trusted()),
                 },
             )
             .await;

--- a/core/src/commands/application_commands.rs
+++ b/core/src/commands/application_commands.rs
@@ -51,9 +51,12 @@ pub async fn insert_application<'a>(params: ApplicationParams) -> ValidationResu
 
     let application = sqlx::query_as!(
         Application,
-        "INSERT INTO applications (name, redirect_url) VALUES ($1, $2) RETURNING *",
+        "INSERT INTO applications (name, redirect_url, trusted_at)
+        VALUES ($1, $2, (CASE WHEN $3 IS TRUE THEN current_timestamp ELSE NULL END))
+        RETURNING *",
         params.name,         // $1
         params.redirect_url, // $2
+        params.trusted,      // $3
     )
     .fetch_one(db_pool)
     .await
@@ -78,10 +81,20 @@ pub async fn update_application<'a>(
 
     let application = sqlx::query_as!(
         Application,
-        "UPDATE applications SET name = $2, redirect_url = $3 WHERE id = $1 RETURNING *",
+        "UPDATE applications
+        SET
+            name = $2,
+            redirect_url = $3,
+            trusted_at = CASE
+                WHEN $4 IS TRUE AND trusted_at IS NOT NULL THEN trusted_at
+                WHEN $4 IS TRUE THEN current_timestamp
+                ELSE NULL END
+        WHERE id = $1
+        RETURNING *",
         application.id,      // $1
         params.name,         // $2
         params.redirect_url, // $3
+        params.trusted,      // $4
     )
     .fetch_one(db_pool)
     .await

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -57,6 +57,7 @@ pub struct Application<'a> {
     pub id: Uuid,
     pub name: Cow<'a, str>,
     pub redirect_url: Cow<'a, str>,
+    pub trusted_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: Option<DateTime<Utc>>,
 }
@@ -68,6 +69,10 @@ impl Display for Application<'_> {
 }
 
 impl Application<'_> {
+    pub fn is_trusted(&self) -> bool {
+        self.trusted_at.is_some()
+    }
+
     pub fn redirect_url(&self) -> Url {
         Url::parse(&self.redirect_url).expect("Could not get Redirect URL")
     }

--- a/core/src/params.rs
+++ b/core/src/params.rs
@@ -59,6 +59,7 @@ pub struct ApplicationParams {
     pub name: String,
     #[validate(url(message = "Is invalid"))]
     pub redirect_url: String,
+    pub trusted: bool,
 }
 
 #[derive(Validate)]

--- a/migrations/20260422183150_add_column_trusted_at_to_applications.down.sql
+++ b/migrations/20260422183150_add_column_trusted_at_to_applications.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE applications DROP COLUMN trusted_at;

--- a/migrations/20260422183150_add_column_trusted_at_to_applications.up.sql
+++ b/migrations/20260422183150_add_column_trusted_at_to_applications.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE applications ADD COLUMN trusted_at timestamptz NULL;


### PR DESCRIPTION
Introduce trusted_at column and migration. Expose trusted in the Application model, params and presenters. Update application create/update commands and CLI to accept a trusted flag. Authorize page now auto-accepts trusted applications and triggers redirect; use get_untracked for action dispatch.